### PR TITLE
Added files for base image of AI Assistant

### DIFF
--- a/aiabase/Dockerfile
+++ b/aiabase/Dockerfile
@@ -1,13 +1,18 @@
 ﻿FROM flexberry/mono-xsp:latest
 
-# Xvfb is installed for Winforms.
 RUN mkdir -p /usr/share/man/man1 && \
     apt-get update && \
+    # Xvfb is installed for Winforms.
     DEBIAN_FRONTEND=noninteractive apt-get install -y xorg xvfb \
         wget python3 python3-pip && \
+    # Tools for spaCy.
     pip3 install -U pip setuptools wheel && \
+    # SpaCy.
     pip3 install -U spacy==3.2.3 && \
+    # Hack to remove damaged version of click (dependency of spaCy).
 	pip uninstall click -y && pip install click==8.0.4 && \
+    # Russian dictionary for spaCy.
     python3 -m spacy download ru_core_news_lg && \
+    # English dictionary for spaCy.
 	python3 -m spacy download en_core_web_trf
 

--- a/aiabase/Dockerfile
+++ b/aiabase/Dockerfile
@@ -1,0 +1,13 @@
+﻿FROM flexberry/mono-xsp:latest
+
+# Xvfb is installed for Winforms.
+RUN mkdir -p /usr/share/man/man1 && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y xorg xvfb \
+        wget python3 python3-pip && \
+    pip3 install -U pip setuptools wheel && \
+    pip3 install -U spacy==3.2.3 && \
+	pip uninstall click -y && pip install click==8.0.4 && \
+    python3 -m spacy download ru_core_news_lg && \
+	python3 -m spacy download en_core_web_trf
+

--- a/aiabase/README.md
+++ b/aiabase/README.md
@@ -1,0 +1,22 @@
+# How to use this image
+This image [flexberry/aiabase](https://hub.docker.com/r/flexberry/aiabase/) is based on customized [flexberry/mono-xsp](https://hub.docker.com/r/flexberry/mono-xsp/) image.
+The image adds python, SpaCy, SpaCy russian and english dictionaries to the base image and is ready to run AI Assisant utilities.
+
+## Create a Dockerfile in your project
+```
+FROM flexberry/aiabase:latest
+
+COPY /app /app
+WORKDIR /app
+```
+
+## How to use booting up
+Ensure BOOTUP_CHECK_URL environment variable is set for best experience. `start_xsp.sh` script makes possible to boot up web server instantly in the background.
+```
+FROM flexberry/aiabase:latest
+
+ENV BOOTUP_CHECK_URL="http://0.0.0.0/"
+
+COPY test /app
+WORKDIR /app
+```

--- a/aiabase/build_docker_image.sh
+++ b/aiabase/build_docker_image.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export REPO=flexberry/aiabase
+
+docker build --no-cache -t $REPO:latest .


### PR DESCRIPTION
Base image for AI Assistant is based on flexberry/mono-xsp.
There are installed all necessary libraries for spaCy work.